### PR TITLE
Update project dependencies and remove redundant ones

### DIFF
--- a/BlazorStaticWebsite/BlazorStaticWebsite.csproj
+++ b/BlazorStaticWebsite/BlazorStaticWebsite.csproj
@@ -12,10 +12,8 @@
   </Target>
   
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.33.0" />
     <!--To showcase it works-->
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.3.1" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorStatic.csproj
+++ b/src/BlazorStatic.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -7,16 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="0.33.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
-        <PackageReference Include="YamlDotNet" Version="13.7.1"/>
+        <PackageReference Include="Markdig" Version="0.37.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="YamlDotNet" Version="15.1.4" />
     </ItemGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="/"/>
+        <None Include="README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Update dependencies and remove redundant ones from `BlazorStaticWebsite`.
Here's a quick overview of what this adds

## BlazorStatic changes

### Markdig

- 0.33 -> 0.37
- Add support for GitHub alert blocks
- add YouTube shorts embed support
- bug fixes and performance improvements

### YamlDotnet

- 13.7.1 -> 14.1.4
- add support for custom formatting of enums and naming conventions for convert enums to/from scalars
- bug fixes and performance improvements

## BlazorStaticWebsite changes

### Markdig

- 0.33 -> deleted (inherits from BlazorStatic)

### YamlDotNet

- 13.7.1 -> deleted (inherits from BlazorStatic)