### PR TITLE
Use the Posts found in './bin' instead of the root directory

### DIFF
--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -83,7 +83,9 @@ public class BlogOptions<TFrontMatter>
     where TFrontMatter : class, IFrontMatter
 {
     /// <summary>
-    /// folder relative to project root where blog posts are stored
+    /// folder relative to project root where blog posts are stored.
+    /// Don't forget to copy the content to bin folder (use CopyToOutputDirectory in .csproj),
+    /// because that's where the app will look for the files.
     /// </summary>
     public string ContentPath { get; set; } = Path.Combine("Content", "Blog");
     /// <summary>

--- a/src/Services/BlogService.cs
+++ b/src/Services/BlogService.cs
@@ -3,6 +3,7 @@ namespace BlazorStatic.Services;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -34,7 +35,7 @@ public class BlogService<TFrontMatter>(BlogOptions<TFrontMatter> options,
     /// </summary>
    public async Task ParseAndAddBlogPosts()
     {
-        var files = Directory.GetFiles(options.ContentPath, options.PostFilePattern);
+        var files = GetPostsPath();
 
         foreach (string file in files)
         {
@@ -69,9 +70,10 @@ public class BlogService<TFrontMatter>(BlogOptions<TFrontMatter> options,
             }
         }
         options.AfterBlogParsedAndAddedAction?.Invoke();
+    }
 
+    private string[] GetPostsPath(){
+        string execFolder = Directory.GetParent(Assembly.GetEntryAssembly().Location).FullName;
+        return Directory.GetFiles(Path.Combine(execFolder, options.ContentPath), options.PostFilePattern);
     }
 }
-
-
-

--- a/src/Services/BlogService.cs
+++ b/src/Services/BlogService.cs
@@ -70,10 +70,12 @@ public class BlogService<TFrontMatter>(BlogOptions<TFrontMatter> options,
             }
         }
         options.AfterBlogParsedAndAddedAction?.Invoke();
+        
+        string[] GetPostsPath(){
+            string execFolder = Directory.GetParent((Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()).Location)!.FullName;//! is ok, null only in empty path or root
+            return Directory.GetFiles(Path.Combine(execFolder, options.ContentPath), options.PostFilePattern);
+        }
     }
 
-    private string[] GetPostsPath(){
-        string execFolder = Directory.GetParent(Assembly.GetEntryAssembly().Location).FullName;
-        return Directory.GetFiles(Path.Combine(execFolder, options.ContentPath), options.PostFilePattern);
-    }
+    
 }


### PR DESCRIPTION
change the path where the **Posts** are searched for, from the root directory of the project to where the assembly of the project is.

original: `src/Content/**`
new: `src/bin/**/netX.0/Content/**`

benefits: allow the user to update the **Posts** pragmatically before parsing them without tampering with the original files.

this also means that the `.csproj` file must contain the following lines:
```xml
<ItemGroup>
  <None Update="Content/**/*">
    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
  </None>
</ItemGroup>
```