### PR TITLE
allow for multiple `IFrontMatter` implementations

### DIFF
--- a/BlazorStaticWebsite/BlazorStaticWebsite.csproj
+++ b/BlazorStaticWebsite/BlazorStaticWebsite.csproj
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Content/**/*">
+    <None Remove="Content/Projects/README.md" />
+    <None Update="Content/**/*" >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/BlazorStaticWebsite/Components/Pages/Projects.razor
+++ b/BlazorStaticWebsite/Components/Pages/Projects.razor
@@ -1,0 +1,50 @@
+﻿@page "/projects"
+@page "/projects/{*postUrl}"
+@using BlazorStatic
+@using BlazorStatic.Services
+@inject BlogService<ProjectFrontMatter> ProjectsService
+
+@* No filename -> show latest posts *@
+@if (string.IsNullOrWhiteSpace(PostUrl))
+{
+    <div class="prose prose-invert">
+        <ul>
+            @foreach (var post in posts)
+            {
+                <li>
+                    <a  href="@ProjectsService.Options.BlogPageUrl/@(post.Url)">@post.FrontMatter.Name</a>
+                    @post.Url
+                </li>
+            }
+        </ul>
+    </div>
+}
+else if (onePost != null)
+{
+    <div class="prose prose-invert">
+        <h1>@onePost.FrontMatter.Name</h1>
+        <p>@onePost.FrontMatter.Description</p>
+        <p>
+            @((MarkupString)onePost.HtmlContent)
+        </p>
+    </div>
+}
+else
+{
+    <div>Projects not found 🤷 </div>
+}
+
+
+@code {
+    [Parameter] public string? PostUrl { get; set; }
+    Post<ProjectFrontMatter>? onePost;
+    List<Post<ProjectFrontMatter>> posts = [];
+
+    protected override void OnInitialized()
+    {
+        if (string.IsNullOrWhiteSpace(PostUrl))
+            posts = ProjectsService.BlogPosts.OrderByDescending(x => x.FrontMatter.Name).ToList();
+        else
+            onePost = ProjectsService.BlogPosts.FirstOrDefault(x => x.Url == PostUrl);
+    }
+}

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.7.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.7.md
@@ -1,0 +1,20 @@
+---
+title: Release of 1.0.0-beta.7
+lead: Allows to use multiple front matter classes, ignores files, and copies static web assets 
+published: 2024-06-10
+tags: [release]
+authors:
+    - name: "Jan Tesař"
+      gitHubUserName: "tesar-tech"
+      twitterUserName: "tesar-tech"
+---
+
+## Breaking changes:
+
+- No property `BeforeFilesGenerationAction` in `BlazorStaticOptions` anymore. Use `BlazorStaticOptions.AddBeforeFilesGenerationFunc`
+  (or `AddBeforeFilesGenerationAction` if you don't need async). Reason for this comes from internal handling of blog post parsing. 
+  Blog posts parsing has no special property (`BlogAction`) now - it is handled by `AddBeforeFilesGenerationFunc`.
+- Blog post are now parsed **after** the custom `beforeFilesGenearionAction` (that you might add via `opt.AddBeforeFilesGenerationFunc/Action`)
+  If you need to parse the blog post first (and operate with them in `opt.AddBeforeFilesGenerationFunc/Action`), use new property `BlogOptions.IsParsingAsFirstAction`
+
+

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.7.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.7.md
@@ -1,20 +1,48 @@
 ---
 title: Release of 1.0.0-beta.7
-lead: Allows to use multiple front matter classes, ignores files, and copies static web assets 
+lead: Allows the use of multiple front matter classes
 published: 2024-06-10
 tags: [release]
 authors:
-    - name: "Jan Tesař"
-      gitHubUserName: "tesar-tech"
-      twitterUserName: "tesar-tech"
+- name: "Jan Tesař"
+gitHubUserName: "tesar-tech"
+twitterUserName: "tesar-tech"
 ---
 
-## Breaking changes:
+## Breaking Changes
 
-- No property `BeforeFilesGenerationAction` in `BlazorStaticOptions` anymore. Use `BlazorStaticOptions.AddBeforeFilesGenerationFunc`
-  (or `AddBeforeFilesGenerationAction` if you don't need async). Reason for this comes from internal handling of blog post parsing. 
-  Blog posts parsing has no special property (`BlogAction`) now - it is handled by `AddBeforeFilesGenerationFunc`.
-- Blog post are now parsed **after** the custom `beforeFilesGenearionAction` (that you might add via `opt.AddBeforeFilesGenerationFunc/Action`)
-  If you need to parse the blog post first (and operate with them in `opt.AddBeforeFilesGenerationFunc/Action`), use new property `BlogOptions.IsParsingAsFirstAction`
+- The `BeforeFilesGenerationAction` property in `BlazorStaticOptions` has been removed. Use `BlazorStaticOptions.AddBeforeFilesGenerationAction` instead. This change is due to internal handling of blog post parsing. Blog post parsing no longer has a special property (`BlogAction`) and is now handled by `AddBeforeFilesGenerationAction`.
+- Blog posts are now parsed **after** the custom `beforeFilesGenerationAction` (which can be added via `opt.AddBeforeFilesGenerationAction`). This change should have no significant effect.
 
+## New Features
 
+- Multiple `BlogServices` can now be used, which is valuable when you have multiple "sections" with different FrontMatter classes. In BlazorStaticWebsite, a new [projects section](projects) was created to demonstrate this usage. See `Program.cs` and `ProjectFrontMatter`.
+
+  ```csharp
+  builder.Services.AddBlogService<FrontMatter>(opt => {
+  }).AddBlogService<ProjectFrontMatter>(opt => {
+    opt.MediaFolderRelativeToContentPath = null;
+    opt.ContentPath = Path.Combine("Content", "Projects");
+    opt.AddTagPagesFromPosts = false;
+    opt.BlogPageUrl = "projects";
+  });
+  ```
+
+  This feature revealed a few refactorings (including the breaking changes) that have been done in this new version. It also highlighted that the name `BlogService` isn't quite precise. We will work on that.
+
+- You can now define the blog media path as `null`, which will remove all warnings and errors related to a non-existent folder.
+
+  ```csharp
+  builder.Services.AddBlogService<ProjectFrontMatter>(opt => {
+    opt.MediaFolderRelativeToContentPath = null;
+  });
+  ```
+
+## Fixes
+
+- The program will no longer fail when the media path doesn't exist. It will issue a warning instead.
+
+  ```shell
+  warn: BlazorStatic.Services.BlogService[0]
+      The folder for the media path (C:\FullPath\BlazorStatic\BlazorStaticWebsite\Content\Projects\media) doesn't exist
+  ```

--- a/BlazorStaticWebsite/Content/Projects/README.md
+++ b/BlazorStaticWebsite/Content/Projects/README.md
@@ -1,0 +1,6 @@
+# Projects 
+
+This is just a demonstration page for using multiple `BlogService<TFrontMatter>` with different front matter classes. 
+
+Blog is using `FrontMatter` class for front matter parsing, this section is using `ProjectFrontMatter` class.
+

--- a/BlazorStaticWebsite/Content/Projects/project1.md
+++ b/BlazorStaticWebsite/Content/Projects/project1.md
@@ -1,0 +1,7 @@
+﻿---
+name: First sample project
+description: Some description text
+tags:  [csharp, blazor, sample]
+---
+
+This only demonstrate the capabilities of BlazorStatic.

--- a/BlazorStaticWebsite/Content/Projects/project2.md
+++ b/BlazorStaticWebsite/Content/Projects/project2.md
@@ -1,0 +1,7 @@
+﻿---
+name: Second sample project
+description: Hello world project
+tags:  [csharp, blazor, sample]
+---
+
+This only demonstrate the capabilities of BlazorStatic.

--- a/BlazorStaticWebsite/Program.cs
+++ b/BlazorStaticWebsite/Program.cs
@@ -1,4 +1,5 @@
 using BlazorStatic;
+using BlazorStaticWebsite;
 using BlazorStaticWebsite.Components;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -12,7 +13,7 @@ builder.Services.AddBlazorStaticService(opt => {
     opt.ContentToCopyToOutput.Add(new("Content/Docs/media", "Content/Docs/media"));
     //add docs pages
     var docsFiles = Directory.GetFiles(Path.Combine("Content", "Docs"), "*.md")
-        .Where(x => !x.EndsWith("README.md"));//ignore readme
+        .Where(x => !x.EndsWith("README.md"));//ignore readme, it is handled in Pages/Docs.razor
 
     foreach (string? fileName in docsFiles.Select(Path.GetFileNameWithoutExtension))
     {
@@ -20,9 +21,13 @@ builder.Services.AddBlazorStaticService(opt => {
     }
 }
 ).AddBlogService<FrontMatter>(opt => {
-
 }
-);
+).AddBlogService<ProjectFrontMatter>(opt => {
+    opt.MediaFolderRelativeToContentPath = null;
+    opt.ContentPath = Path.Combine("Content", "Projects");
+    opt.AddTagPagesFromPosts = false;
+    opt.BlogPageUrl = "projects";
+});
 
 
 // Add services to the container.
@@ -57,6 +62,7 @@ app.UseAntiforgery();
 app.MapRazorComponents<App>();
 
 app.UseBlog<FrontMatter>();
+app.UseBlog<ProjectFrontMatter>();
 app.UseBlazorStaticGenerator(shutdownApp: !app.Environment.IsDevelopment());
 
 app.Run();

--- a/BlazorStaticWebsite/ProjectFrontMatter.cs
+++ b/BlazorStaticWebsite/ProjectFrontMatter.cs
@@ -1,0 +1,11 @@
+﻿namespace BlazorStaticWebsite;
+
+using BlazorStatic;
+
+public class ProjectFrontMatter:IFrontMatter
+{
+    public List<string> Tags { get; set; } = [];
+    public string Name  { get; set; } = "";
+    public string Description { get; set; } = "";
+}
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ BlazorStatic:
   ```
 
 - Provides `FrontMatter` class for parsing blog post metadata.
-- Allows for custom `IFrontMatter` implementations to suit various markdown (front matter) formats.
+- Allows for custom `IFrontMatter` implementations to suit various markdown (front matter) formats. You can even have multiple sections with multiple `IFrontMatter` classes.
 
 - Facilitates copying necessary files to the output folder:
 

--- a/src/BlazorStatic.csproj
+++ b/src/BlazorStatic.csproj
@@ -25,7 +25,7 @@
         <Description>Static site generator for Blazor on .NET8.</Description>
         <PackageId>BlazorStatic</PackageId>
         <!--Set EnvironmentName using dotnet build -c Release -p:EnvironmentName=Development for local package build-->
-        <Version Condition="'$(EnvironmentName)' != 'Development'">1.0.0-beta.6</Version>
+        <Version Condition="'$(EnvironmentName)' != 'Development'">1.0.0-beta.7</Version>
         <Version Condition="'$(EnvironmentName)' == 'Development'">1.0.0-dev.$([System.DateTime]::Now.ToString("yyMMddHHmmss"))</Version>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <RepositoryUrl>https://github.com/tesar-tech/BlazorStatic/</RepositoryUrl>

--- a/src/BlazorStaticExtensions.cs
+++ b/src/BlazorStaticExtensions.cs
@@ -97,7 +97,7 @@ public static class BlazorStaticExtensions
         });
         //
         
-        blazorStaticService.Options.AddBeforeFilesGenerationFunc(blogService.ParseAndAddBlogPosts, isAsFirst:options.IsParsingAsFirstAction); //will run later in GenerateStaticPages
+        blazorStaticService.Options.AddBeforeFilesGenerationAction(blogService.ParseAndAddBlogPosts); //will run later in GenerateStaticPages
         
     }
     

--- a/src/BlazorStaticExtensions.cs
+++ b/src/BlazorStaticExtensions.cs
@@ -97,7 +97,7 @@ public static class BlazorStaticExtensions
         });
         //
         
-        blazorStaticService.BlogAction = blogService.ParseAndAddBlogPosts;//will run later 
+        blazorStaticService.BlogActions.Add(blogService.ParseAndAddBlogPosts); //will run later 
         //in GenerateStaticPages
         
     }

--- a/src/BlazorStaticExtensions.cs
+++ b/src/BlazorStaticExtensions.cs
@@ -97,8 +97,7 @@ public static class BlazorStaticExtensions
         });
         //
         
-        blazorStaticService.BlogActions.Add(blogService.ParseAndAddBlogPosts); //will run later 
-        //in GenerateStaticPages
+        blazorStaticService.Options.AddBeforeFilesGenerationFunc(blogService.ParseAndAddBlogPosts, isAsFirst:options.IsParsingAsFirstAction); //will run later in GenerateStaticPages
         
     }
     

--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -145,6 +145,7 @@ public class BlogOptions<TFrontMatter>
     
     /// <summary>
     /// Should correspond to @page "/blog" (here in relative path: "blog")
+    /// This also serves as a generated folder in blog posts
     /// Useful for avoiding magic strings in .razor files
     /// </summary>
     public string BlogPageUrl { get; set; } = "blog";

--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -79,7 +79,7 @@ public class BlazorStaticOptions
     /// </summary>
     public List<string> IgnoredPathsOnContentCopy { get; } = [];
     /// <summary>
-    /// Paths (files or dirs) relative to project root, that should be copied to output folder
+    /// Paths (files or dirs) relative to project root, that should be copied to output folder.
     /// Content from RCLs (from _content/) and wwwroot is copied by default
     /// </summary>
     public List<ContentToCopy> ContentToCopyToOutput { get; } = [];
@@ -116,18 +116,20 @@ public class BlogOptions<TFrontMatter>
     public string ContentPath { get; set; } = Path.Combine("Content", "Blog");
     /// <summary>
     /// folder in ContentPath where media files are stored.
-    /// Important for app.UseStaticFiles targeting the correct folder
+    /// Important for app.UseStaticFiles targeting the correct folder.
+    /// Null in case of no media folder
     /// </summary>
-    public string MediaFolderRelativeToContentPath { get; set; } = "media";
+    public string? MediaFolderRelativeToContentPath { get; set; } = "media";
     /// <summary>
     /// URL path for media files for blog posts.
     /// Used in app.UseStaticFiles to target the correct folder
     /// and in ParseBlogPosts to generate correct URLs for images
     /// changes ![alt](media/image.png) to ![alt](Content/Blog/media/image.png
     /// leading slash / is necessary for RequestPath in app.UseStaticFiles,
-    /// is removed in ParseBlogPosts
+    /// is removed in ParseBlogPosts.
+    /// Null in case of no media.
     /// </summary>
-    public string MediaRequestPath => Path.Combine(ContentPath, MediaFolderRelativeToContentPath).Replace(@"\", "/");
+    public string? MediaRequestPath => MediaFolderRelativeToContentPath is null? null: Path.Combine(ContentPath, MediaFolderRelativeToContentPath).Replace(@"\", "/");
     /// <summary>
     /// pattern for blog post files in ContentPath
     /// </summary>

--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -52,29 +52,22 @@ public class BlazorStaticOptions
 
     
     /// <summary>
-    /// Adds a function to the list of actions to be executed before files are generated.
+    /// Adds an async Func to the list of actions to be executed before files are generated.
     /// </summary>
-    /// <param name="func">The function to add.</param>
-    /// <param name="isAsFirst">If true, the function is added to the beginning of the list; otherwise, it is added to the end.</param>
-    public void AddBeforeFilesGenerationFunc(Func<Task> func, bool isAsFirst = false)
-    {
-        if (isAsFirst)
-            _beforeFilesGenerationActions.Insert(0, func);
-        else
-            _beforeFilesGenerationActions.Add(func);
-    }
-    
+    /// <param name="func">The asynchronous function to add.</param>
+    public void AddBeforeFilesGenerationAction(Func<Task> func) => _beforeFilesGenerationActions.Add(func);
+
     /// <summary>
     /// Adds an action to the list of actions to be executed before files are generated.
     /// </summary>
-    /// <param name="action">The action to add.</param>
-    /// <param name="isAsFirst">If true, the action is added to the beginning of the list; otherwise, it is added to the end.</param>
-    public void AddBeforeFilesGenerationAction(Action action, bool isAsFirst = false) =>
-        AddBeforeFilesGenerationFunc(() =>
+    /// <param name="action">The synchronous action to add.</param>
+    public void AddBeforeFilesGenerationAction(Action action) =>
+        AddBeforeFilesGenerationAction(() =>
         {
             action();
             return Task.CompletedTask;
-        }, isAsFirst);
+        });
+
 
 
 
@@ -165,9 +158,4 @@ public class BlogOptions<TFrontMatter>
     /// </summary>
     public Action? AfterBlogParsedAndAddedAction { get; set; }
     
-    /// <summary>
-    /// Allows to run parsing of blog posts as the first action for blazorStaticService.Options.AddBeforeFilesGenerationFunc
-    /// e.g. in a need of affecting the blog post collection in AddBlazorStaticService
-    /// </summary>
-    public bool IsParsingAsFirstAction { get; set; }
 }

--- a/src/Services/BlazorStaticService.cs
+++ b/src/Services/BlazorStaticService.cs
@@ -17,7 +17,7 @@ public class BlazorStaticService(BlazorStaticOptions options,
     /// The BlazorStaticOptions used to configure the generation process.
     /// </summary>
     public BlazorStaticOptions Options => options;
-    internal Func<Task>? BlogAction { get; set; }
+    internal List<Func<Task>?> BlogActions { get; set; } = new();
     
     /// <summary>
     /// Generates static pages for the Blazor application. This method performs several key operations:
@@ -32,8 +32,12 @@ public class BlazorStaticService(BlazorStaticOptions options,
     /// <param name="appUrl">The base URL of the application, used for making HTTP requests to fetch page content.</param>
     internal async Task GenerateStaticPages(string appUrl)
     {
-        if (BlogAction is not null)
-            await BlogAction.Invoke();
+        foreach(var action in BlogActions)
+        {
+            if (action is not null)
+                await action.Invoke();
+        }
+
         if (options.SuppressFileGeneration) return;
 
         if (options.AddNonParametrizedRazorPages)

--- a/src/Services/BlazorStaticService.cs
+++ b/src/Services/BlazorStaticService.cs
@@ -31,7 +31,6 @@ public class BlazorStaticService(BlazorStaticOptions options,
     /// <param name="appUrl">The base URL of the application, used for making HTTP requests to fetch page content.</param>
     internal async Task GenerateStaticPages(string appUrl)
     {
-        if (options.SuppressFileGeneration) return;
 
         if (options.AddNonParametrizedRazorPages)
             AddNonParametrizedRazorPages();
@@ -40,6 +39,7 @@ public class BlazorStaticService(BlazorStaticOptions options,
         {
             await action.Invoke();
         }
+        if (options.SuppressFileGeneration) return;
 
         if (Directory.Exists(options.OutputFolderPath))//clear output folder
             Directory.Delete(options.OutputFolderPath, true);

--- a/src/Services/BlogService.cs
+++ b/src/Services/BlogService.cs
@@ -58,7 +58,7 @@ public class BlogService<TFrontMatter>(
             };
             options.Posts.Add(post);
 
-            blazorStaticService.Options.PagesToGenerate.Add(new($"{options.BlogPageUrl}/{post.Url}", Path.Combine("blog", $"{post.Url}.html")));
+            blazorStaticService.Options.PagesToGenerate.Add(new($"{options.BlogPageUrl}/{post.Url}", Path.Combine(options.BlogPageUrl, $"{post.Url}.html")));
         }
 
         //copy media folder to output


### PR DESCRIPTION
Allow the user to pass multiple implementations of the front matter interface.

I'm making a personal website with 2 main pages one for "projects" and the other for "blogs" which have different properties.

I can make a generic model that encapsulates both types and sort them by folder name or an enum but it's honestly easier this way.

Without this change the library will only store the last `UseBlog`.

Usage:

```cs
// this part stays the same
builder.Services.AddBlogService<ProjectsFrontMatter>(opt =>
{
    opt.BlogPageUrl = "Projects";
    opt.ContentPath = Path.Combine("Content","Projects");
});

builder.Services.AddBlogService<BlogsFrontMatter>(opt =>
{
    opt.BlogPageUrl = "Blogs";
    opt.ContentPath = Path.Combine("Content","Blogs");
});

// add an extra "UseBlog" for each blogService
app.UseBlog<ProjectsFrontMatter>();
app.UseBlog<BlogsFrontMatter>();
```

*If i missed something or there's a better way of doing this then please tell me*