### PR TITLE
better solution to register pages to generate as static files

### DIFF
--- a/BlazorStaticWebsite/Components/Pages/Projects.razor
+++ b/BlazorStaticWebsite/Components/Pages/Projects.razor
@@ -1,5 +1,10 @@
-﻿@page "/projects"
-@page "/projects/{*postUrl}"
+﻿
+@*instead of @page "/projects"  *@
+@attribute [Route($"/{WebsiteKeys.ProjectsUrl}")] 
+
+@*instead of @page "/projects/{*postUrl}"  *@
+@attribute [Route($"/{WebsiteKeys.ProjectsUrl}/{{*postUrl}}")] 
+
 @using BlazorStatic
 @using BlazorStatic.Services
 @inject BlazorStaticContentService<ProjectFrontMatter> projectsService

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.10.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.10.md
@@ -11,16 +11,14 @@ authors:
   gitHubUserName: "MeltyObserver"
 ---
 
-
-
 ## Breaking Changes
 
-- `RazorPagesPaths` is no longer availabl~~~~e. It was used to get the location of razor pages where to scan for `@page` directive. 
-Since now, it scans the assembly, this is no longer needed.  
+- `RazorPagesPaths` is no longer available. It was used to get the location of razor pages to scan for the `@page` directive.
+  Now, BlazorStatic scans the assembly for all pages.
 
 ## Features
 
-- Now you don't need to use `@page` directive, but you can use `Route` attribute (`@page` directive is translated to that anyway)
+- You no longer need to use the `@page` directive; you can use the `Route` attribute instead (the `@page` directive is translated to that anyway).
 
 Before:
 
@@ -34,9 +32,11 @@ After:
 @attribute [Route("/projects")]*@
 ```
 
-Well - you might say it is uglier now and you would be right. The `@page` directive is there to simplify the `Route` attribute usage.
-But it doesn't support anything else except strings... You might want to (and I recommend) that to avoid magic strings and keep all the
-routes in single place. For example here in BlazorStaticWebsite the `projects` page is defined with:
+
+You might say it is uglier now, and you would be right.
+The `@page` directive simplifies the usage of the `Route` attribute, but it only supports strings.
+To avoid magic strings and keep all routes in a single place, I recommend defining routes centrally.
+For example, in BlazorStaticWebsite, the `projects` page is defined as:
 
 ```
 @attribute [Route($"/{WebsiteKeys.ProjectsUrl}")]

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.10.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.10.md
@@ -1,0 +1,48 @@
+---
+title: 1.0.0-beta.10 - Better way of finding pages 
+lead: No need for magic strings in routes
+published: 2024-08-10
+tags: [release]
+authors:
+- name: "Jan Tesař"
+  gitHubUserName: "tesar-tech"
+  xUserName: "tesar_tech"
+- name: "Melty Observer"
+  gitHubUserName: "MeltyObserver"
+---
+
+
+
+## Breaking Changes
+
+- `RazorPagesPaths` is no longer availabl~~~~e. It was used to get the location of razor pages where to scan for `@page` directive. 
+Since now, it scans the assembly, this is no longer needed.  
+
+## Features
+
+- Now you don't need to use `@page` directive, but you can use `Route` attribute (`@page` directive is translated to that anyway)
+
+Before:
+
+```
+@page "/projects"
+```
+
+After:
+
+```
+@attribute [Route("/projects")]*@
+```
+
+Well - you might say it is uglier now and you would be right. The `@page` directive is there to simplify the `Route` attribute usage.
+But it doesn't support anything else except strings... You might want to (and I recommend) that to avoid magic strings and keep all the
+routes in single place. For example here in BlazorStaticWebsite the `projects` page is defined with:
+
+```
+@attribute [Route($"/{WebsiteKeys.ProjectsUrl}")]
+```
+
+Which keeps the `project` string definition in one place. 
+
+
+

--- a/BlazorStaticWebsite/Program.cs
+++ b/BlazorStaticWebsite/Program.cs
@@ -27,7 +27,7 @@ builder.Services.AddBlazorStaticService(opt => {
         opt.MediaFolderRelativeToContentPath = null;
         opt.ContentPath = Path.Combine("Content", "Projects");
         opt.AddTagPagesFromPosts = false;
-        opt.PageUrl = "projects";
+        opt.PageUrl = WebsiteKeys.ProjectsUrl;
     });
 
 
@@ -72,4 +72,7 @@ public static class WebsiteKeys
     public const string BlogPostStorageAddress = "https://github.com/tesar-tech/BlazorStatic/tree/master/BlazorStaticWebsite/Content/Blog/";
 
     public const string GitHubRepo = "https://github.com/tesar-tech/BlazorStatic/";
+
+    public const string ProjectsUrl = "projects";
+
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are a lot of defaults to keep usage simple, but you can configure it exten
 - Work with Blazor as you are used to.
 - Easily parse and consume markdown files.
 - Support for custom YAML front matters.
-- Automatically discovers pages to generate by scanning for the `@page` directive in Razor files.
+- Automatically discovers pages among Razor files.
 - Ability to add/remove pages as needed.
 - Works with all CSS frameworks and themes.
 - Easy to deploy with CI/CD pipeline.

--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -19,7 +19,7 @@ public class BlazorStaticOptions
     public bool SuppressFileGeneration { get; set; }
     
     /// <summary>
-    /// List of pages to generate with url to call and path of .html file to generate.
+    /// List of routes to generate as static html files.
     /// </summary>
     public List<PageToGenerate> PagesToGenerate { get; } = [];
     

--- a/src/Services/BlazorStaticService.cs
+++ b/src/Services/BlazorStaticService.cs
@@ -1,7 +1,7 @@
 namespace BlazorStatic.Services;
 
 using Microsoft.Extensions.Logging;
-using System.Text.RegularExpressions;
+using System.Reflection;
 
 /// <summary>
 /// The BlazorStaticService is responsible for generating static pages for a Blazor application.
@@ -33,30 +33,32 @@ public class BlazorStaticService(BlazorStaticOptions options,
     {
 
         if (options.AddNonParametrizedRazorPages)
-            AddNonParametrizedRazorPages();
-        
+            RegisterNonTokenizedPages();
+
         foreach (Func<Task> action in options.GetBeforeFilesGenerationActions())
         {
             await action.Invoke();
         }
+
         if (options.SuppressFileGeneration) return;
 
-        if (Directory.Exists(options.OutputFolderPath))//clear output folder
+        if (Directory.Exists(options.OutputFolderPath)) //clear output folder
             Directory.Delete(options.OutputFolderPath, true);
         Directory.CreateDirectory(options.OutputFolderPath);
 
         List<string> ignoredPathsWithOutputFolder = options.IgnoredPathsOnContentCopy.Select(x => Path.Combine(options.OutputFolderPath, x)).ToList();
         foreach (var pathToCopy in options.ContentToCopyToOutput)
         {
-            logger.LogInformation("Copying {sourcePath} to {targetPath}", pathToCopy.SourcePath, Path.Combine(options.OutputFolderPath,  pathToCopy.TargetPath ));
+            logger.LogInformation("Copying {sourcePath} to {targetPath}", pathToCopy.SourcePath, Path.Combine(options.OutputFolderPath, pathToCopy.TargetPath));
             helpers.CopyContent(pathToCopy.SourcePath, Path.Combine(options.OutputFolderPath, pathToCopy.TargetPath), ignoredPathsWithOutputFolder);
         }
-
 
         HttpClient client = new() { BaseAddress = new Uri(appUrl) };
 
         foreach (PageToGenerate page in options.PagesToGenerate)
         {
+            if (page is null) continue;
+
             logger.LogInformation("Generating {pageUrl} into {pageOutputFile}", page.Url, page.OutputFile);
             string content;
             try
@@ -69,57 +71,28 @@ public class BlazorStaticService(BlazorStaticOptions options,
                 continue;
             }
 
-            var outFilePath = Path.Combine(options.OutputFolderPath, page.OutputFile);
+            var outFilePath = Path.Combine(options.OutputFolderPath, page.OutputFile.TrimStart('/'));
 
             string? directoryPath = Path.GetDirectoryName(outFilePath);
-            if (directoryPath != null)
+            if (!string.IsNullOrEmpty(directoryPath))
                 Directory.CreateDirectory(directoryPath);
+
             await File.WriteAllTextAsync(outFilePath, content);
         }
     }
+
     /// <summary>
-    /// Adds non-parametrized Razor pages to the list of pages to be generated as static content.
-    /// This method scans specified directories for Razor files and identifies those with a @page directive
-    /// that do not include parameters (i.e., no '{}' in the directive). For each matching file, it constructs
-    /// a URL based on the @page directive and determines a corresponding file path for the static HTML output.
-    /// The method assumes that each URL path should map to a folder structure with an 'index.html' file in it,
-    /// as specified in options.IndexPageHtml.
+    /// Registers razor pages that have no parameters to be generated as static pages.
     /// </summary>
-    /// <remarks>
-    /// This operation is controlled by the options.AddNonParametrizedRazorPages flag. Only Razor files in
-    /// directories specified in options.RazorPagesPaths are considered. The method employs regular expression
-    /// matching to identify suitable @page directives.
-    /// </remarks>
-    void AddNonParametrizedRazorPages()
+    private void RegisterNonTokenizedPages()
     {
-        if (!options.AddNonParametrizedRazorPages) return;
+        var entryAssembly = Assembly.GetEntryAssembly()!;
+        List<string?> routesToGenerate = RoutesHelper.GetRoutesToRender(entryAssembly);
 
-        var regex = new Regex("""
-                              @page "/(?!.*\{.*\})(.*?)"
-                              """);// Regular expression to match @page directive, but ignore when {} are present
-
-        var allRazorFilePaths = new List<string>();
-
-        foreach (var path in options.RazorPagesPaths)
+        foreach (var route in routesToGenerate)
         {
-            var filePaths = Directory.GetFiles(path, "*.razor");
-            allRazorFilePaths.AddRange(filePaths);
-        }
-        foreach (var filePath in allRazorFilePaths)
-        {
-            var content = File.ReadAllText(filePath);
-
-            var match = regex.Match(content);
-            if (match is not { Success: true, Groups.Count: > 1 })
-                continue;
-            string url = match.Groups[1].Value;
-            string file = Path.Combine(url, options.IndexPageHtml);//for @page "/blog" generate blog/index.html 
-            options.PagesToGenerate.Add(new($"{url}", file));
+            if (route is null) continue;
+            options.PagesToGenerate.Add(new (route, Path.Combine(route, options.IndexPageHtml)));
         }
     }
 }
-
-
-
-
-

--- a/src/Services/BlazorStaticService.cs
+++ b/src/Services/BlazorStaticService.cs
@@ -33,7 +33,7 @@ public class BlazorStaticService(BlazorStaticOptions options,
     {
 
         if (options.AddNonParametrizedRazorPages)
-            RegisterNonTokenizedPages();
+            AddPagesWithoutParameters();
 
         foreach (Func<Task> action in options.GetBeforeFilesGenerationActions())
         {
@@ -82,8 +82,9 @@ public class BlazorStaticService(BlazorStaticOptions options,
 
     /// <summary>
     /// Registers razor pages that have no parameters to be generated as static pages.
+    /// Page is defined by Route parameter: either `@page "Example"` or `@attribute [Route("Example")]`  
     /// </summary>
-    private void RegisterNonTokenizedPages()
+    private void AddPagesWithoutParameters()
     {
         var entryAssembly = Assembly.GetEntryAssembly()!;
         List<string> routesToGenerate = RoutesHelper.GetRoutesToRender(entryAssembly);

--- a/src/Services/BlazorStaticService.cs
+++ b/src/Services/BlazorStaticService.cs
@@ -57,7 +57,6 @@ public class BlazorStaticService(BlazorStaticOptions options,
 
         foreach (PageToGenerate page in options.PagesToGenerate)
         {
-            if (page is null) continue;
 
             logger.LogInformation("Generating {pageUrl} into {pageOutputFile}", page.Url, page.OutputFile);
             string content;
@@ -87,11 +86,10 @@ public class BlazorStaticService(BlazorStaticOptions options,
     private void RegisterNonTokenizedPages()
     {
         var entryAssembly = Assembly.GetEntryAssembly()!;
-        List<string?> routesToGenerate = RoutesHelper.GetRoutesToRender(entryAssembly);
+        List<string> routesToGenerate = RoutesHelper.GetRoutesToRender(entryAssembly);
 
         foreach (var route in routesToGenerate)
         {
-            if (route is null) continue;
             options.PagesToGenerate.Add(new (route, Path.Combine(route, options.IndexPageHtml)));
         }
     }

--- a/src/Services/RoutesHelper.cs
+++ b/src/Services/RoutesHelper.cs
@@ -1,0 +1,53 @@
+namespace BlazorStatic.Services;
+
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+// borrowed code with minor changes
+// https://andrewlock.net/finding-all-routable-components-in-a-webassembly-app/
+internal static class RoutesHelper
+{
+    public static List<string?> GetRoutesToRender(Assembly assembly)
+    {
+        // Get all the components whose base class is ComponentBase
+        var components = assembly
+            .ExportedTypes
+            .Where(t => t.IsSubclassOf(typeof(ComponentBase)));
+
+        var routes = components
+            .Select(GetRouteFromComponent)
+            .Where(config => config is not null)
+            .ToList();
+
+        return routes;
+    }
+
+    private static string? GetRouteFromComponent(Type component)
+    {
+        var attributes = component.GetCustomAttributes(inherit: true);
+
+        var routeAttribute = attributes.OfType<RouteAttribute>().FirstOrDefault();
+
+        if (routeAttribute is null)
+        {
+            // Only map rout-able components
+            return null;
+        }
+
+        var route = routeAttribute.Template;
+
+        if (string.IsNullOrEmpty(route))
+        {
+            throw new Exception($"RouteAttribute in component '{component}' has empty route template");
+        }
+
+        // Doesn't support tokens yet
+        if (route.Contains('{'))
+        {
+            // throw new Exception($"RouteAttribute for component '{component}' contains route values. Route values are invalid for prerendering");
+            return null;
+        }
+
+        return route;
+    }
+}

--- a/src/Services/RoutesHelper.cs
+++ b/src/Services/RoutesHelper.cs
@@ -7,21 +7,35 @@ using Microsoft.AspNetCore.Components;
 // https://andrewlock.net/finding-all-routable-components-in-a-webassembly-app/
 internal static class RoutesHelper
 {
-    public static List<string?> GetRoutesToRender(Assembly assembly)
+    /// <summary>
+    /// Gets the static routes of a blazor app
+    /// </summary>
+    /// <param name="assembly">assembly of the blazor app</param>
+    /// <returns>a list of static routes</returns>
+    public static List<string> GetRoutesToRender(Assembly assembly)
     {
         // Get all the components whose base class is ComponentBase
         var components = assembly
             .ExportedTypes
             .Where(t => t.IsSubclassOf(typeof(ComponentBase)));
 
+        // get all the routes that don't contain parameters
         var routes = components
             .Select(GetRouteFromComponent)
-            .Where(config => config is not null)
+            .Where(route => route is not null)
             .ToList();
 
-        return routes;
+        return routes!;
     }
 
+    /// <summary>
+    ///  Gets the route from a blazor component
+    /// </summary>
+    /// <param name="component"></param>
+    /// <returns>
+    /// The route of the component.
+    /// Returns null if the component is not a page or the route has parameters.
+    /// </returns>
     private static string? GetRouteFromComponent(Type component)
     {
         var attributes = component.GetCustomAttributes(inherit: true);
@@ -36,15 +50,9 @@ internal static class RoutesHelper
 
         var route = routeAttribute.Template;
 
-        if (string.IsNullOrEmpty(route))
-        {
-            throw new Exception($"RouteAttribute in component '{component}' has empty route template");
-        }
-
-        // Doesn't support tokens yet
+        // can't work with parameterized pages
         if (route.Contains('{'))
         {
-            // throw new Exception($"RouteAttribute for component '{component}' contains route values. Route values are invalid for prerendering");
             return null;
         }
 


### PR DESCRIPTION
better solution to generate routes, this would also eliminate the need for `BlazorStaticOptions.RazorPagesPaths`

Pros:
- less prone to failing
- allows for the use of `@attribute [Route(...)]`
- should be faster

Cons:
- uses reflection