### PR TITLE
Add flag to exclude example posts on new template.

### DIFF
--- a/BlazorStaticTemplates/pack_and_test.ps1
+++ b/BlazorStaticTemplates/pack_and_test.ps1
@@ -13,4 +13,4 @@ Write-Host "Removing the old 'TestProject' directory..." -ForegroundColor Cyan
 Remove-Item -Recurse -Force -Path ".\TestProject"
 
 Write-Host "Creating a new project from the 'BlazorStaticMinimalBlog' template..." -ForegroundColor Cyan
-dotnet new BlazorStaticMinimalBlog -o "TestProject" --force
+dotnet new BlazorStaticMinimalBlog -o "TestProject" --force -e

--- a/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/dotnetcli.host.json
+++ b/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "ExcludeDefaultPosts": {
+      "longName": "exclude-default-posts",
+      "shortName": "e"
+    }
+  }
+}

--- a/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/template.json
+++ b/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/template.json
@@ -16,6 +16,7 @@
   "sourceName": "BlazorStaticMinimalBlog",
   "defaultName": "MyBlazorStaticApp",
   "preferNameDirectory": true,
+  "placeholderFilename":".keepFolder",
   "sources": [
     {
       "modifiers": [
@@ -29,7 +30,8 @@
         {
           "condition": "(ExcludeDefaultPosts)",
           "exclude": [
-            "**/Content/Blog/**"
+            "**/Content/Blog/**/*.md",
+            "**/Content/Blog/media/**"
           ]
         },
         {

--- a/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/template.json
+++ b/BlazorStaticTemplates/templates/BlazorStaticMinimalBlogTemplate/.template-config/template.json
@@ -1,61 +1,78 @@
 {
-    "$schema": "http://json.schemastore.org/template",
-    "author": "tesar.tech",
-    "classifications": ["Web","Blazor", "Static"],
-    "identity": "BlazorStatic.Templates", 
-    "name": "BlazorStatic Minimal Blog Site Template",
-    "shortName": "BlazorStaticMinimalBlog",
-    "tags": {
-      "language": "C#",
-      "type": "project"
-    },
-    "sourceName": "BlazorStaticMinimalBlog",
-    "defaultName": "MyBlazorStaticApp",
-    "preferNameDirectory": true,         
-    "sources": [
-      {
-        "modifiers": [
-          {
-            "condition": "(!Exclude)",
-            "exclude": [ "**/bin/**", "**/obj/**" ]
-          },
-          {
-            "condition": "true",  
-            "exclude": [
-              "./BlazorStaticMinimalBlog/.git",
-              ".git"
-            ]
-          }
-        ],
-        "source": "./BlazorStaticMinimalBlog"   
-      }
-    ],
-    "symbols": {
-      "UseInTemplate": {
-        "type": "parameter",
-        "datatype": "bool",
-        "defaultValue": "true",
-        "replaces": "UseInTemplate"
-      }, 
-      "HTTPS_PORT": {
-        "type": "generated",
-        "generator": "random",
-        "parameters": {
-          "low": 7000,
-          "high": 7300
+  "$schema": "http://json.schemastore.org/template",
+  "author": "tesar.tech",
+  "classifications": [
+    "Web",
+    "Blazor",
+    "Static"
+  ],
+  "identity": "BlazorStatic.Templates",
+  "name": "BlazorStatic Minimal Blog Site Template",
+  "shortName": "BlazorStaticMinimalBlog",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "BlazorStaticMinimalBlog",
+  "defaultName": "MyBlazorStaticApp",
+  "preferNameDirectory": true,
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!Exclude)",
+          "exclude": [
+            "**/bin/**",
+            "**/obj/**"
+          ]
         },
-        "replaces": "7103"
-      },
-      "HTTP_PORT": {
-        "type": "generated",
-        "generator": "random",
-        "parameters": {
-          "low": 5000,
-          "high": 5300
+        {
+          "condition": "(ExcludeDefaultPosts)",
+          "exclude": [
+            "**/Content/Blog/**"
+          ]
         },
-        "replaces": "5077"
-      }
+        {
+          "condition": "true",
+          "exclude": [
+            "./BlazorStaticMinimalBlog/.git",
+            ".git"
+          ]
+        }
+      ],
+      "source": "./BlazorStaticMinimalBlog"
     }
-  
+  ],
+  "symbols": {
+    "ExcludeDefaultPosts": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Skip copying over the default example posts."
+    },
+    "UseInTemplate": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "replaces": "UseInTemplate"
+    },
+    "HTTPS_PORT": {
+      "type": "generated",
+      "generator": "random",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      },
+      "replaces": "7103"
+    },
+    "HTTP_PORT": {
+      "type": "generated",
+      "generator": "random",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      },
+      "replaces": "5077"
+    }
   }
-  
+}


### PR DESCRIPTION
This should solve part of #37

I ran my formatter in Rider so if you're not a fan of that feel free to let me know and I can try to revert it but this is what the other template.json formatting looked like when I was examining them. I also added a CLI json file that let's us rename short and long names to match other templates like ASP.NET so you can do kebab-case. I can try to look into doing one for Tailwind in the future as well.