### PR TITLE
tags improvements - non-url characters

### DIFF
--- a/.github/workflows/publish-to-ghpages-and-nuget.yml
+++ b/.github/workflows/publish-to-ghpages-and-nuget.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Run webapp and generate static files
         run: dotnet run --project ${{ env.WEBAPP_PATH }}/${{env.WEBAPP_CSPROJ}}  --configuration Release
 
-
       - name: Upload webapp output artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-to-ghpages-and-nuget.yml
+++ b/.github/workflows/publish-to-ghpages-and-nuget.yml
@@ -3,7 +3,7 @@ name: Build, publish to gh pages and nuget
 
 on:
   push:
-    branches: ["*"]
+    branches: ["master"]
 env:
   WEBAPP_PATH: BlazorStaticWebsite
   TEMPLATE_PROJ_PATH: BlazorStaticTemplates/BlazorStatic.Templates.csproj

--- a/BlazorStaticWebsite/BlazorStaticWebsite.csproj
+++ b/BlazorStaticWebsite/BlazorStaticWebsite.csproj
@@ -18,6 +18,9 @@
 
   <ItemGroup>
     <None Remove="output\**"/>
+    <None Update="Content\Blog\release-1.0.0-beta.14.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorStaticWebsite/BlazorStaticWebsite.csproj
+++ b/BlazorStaticWebsite/BlazorStaticWebsite.csproj
@@ -18,9 +18,6 @@
 
   <ItemGroup>
     <None Remove="output\**"/>
-    <None Update="Content\Blog\release-1.0.0-beta.14.md">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorStaticWebsite/Components/Blog/PostsList.razor
+++ b/BlazorStaticWebsite/Components/Blog/PostsList.razor
@@ -4,7 +4,7 @@
 @inject BlazorStaticContentService<BlogFrontMatter> blazorStaticContentService
 @inject BlazorStaticService blazorStaticService
 
-<ul class="divide-y   divide-gray-700">
+<ul class="divide-y divide-gray-700">
     @foreach(var post in posts)
     {
         <li class="py-12">
@@ -29,7 +29,7 @@
                                 <div class="flex flex-wrap">
                                     @foreach(string tag in post.FrontMatter.Tags)
                                     {
-                                        <a class="text-primary-500 hover:text-primary-400 mr-3 text-sm font-medium uppercase" href="@blazorStaticContentService.Options.TagsPageUrl/@tag">@tag</a>
+                                        <a class="text-primary-500 hover:text-primary-400 mr-3 text-sm font-medium uppercase" href="@blazorStaticContentService.Options.TagsPageUrl/@blazorStaticContentService.Options.TagEncodeFunc(tag)">@tag</a>
                                     }
                                 </div>
                             </div>

--- a/BlazorStaticWebsite/Components/Pages/Tags.razor
+++ b/BlazorStaticWebsite/Components/Pages/Tags.razor
@@ -1,4 +1,4 @@
-@page "/tags/{tagName}"
+@page "/tags/{TagEncodedName}"
 @page "/tags"
 @using BlazorStatic
 @using BlazorStatic.Services
@@ -6,7 +6,7 @@
 @using System.Net
 @inject BlazorStaticContentService<BlogFrontMatter> BlazorStaticContentService
 
-@if (TagName == null)
+@if (TagEncodedName == null)
 {
     <div class="flex flex-wrap justify-between gap-1">
         @{
@@ -28,10 +28,10 @@
 
 <div class="divide-y divide-gray-700">
     <div class="space-y-2 pb-8 pt-6 md:space-y-5">
-        <h1 class="font-sans md:leading-14 text-3xl font-extrabold leading-9 tracking-tight text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl">@TagName</h1>
+        <h1 class="font-sans md:leading-14 text-3xl font-extrabold leading-9 tracking-tight text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl">@TagEncodedName</h1>
         <p class="text-lg leading-7 text-gray-400">
             Blog posts tagged by
-            <span class="text-primary-300">@TagName</span>
+            <span class="text-primary-300">@TagEncodedName</span>
         </p>
     </div>
     <PostsList Posts="posts"/>
@@ -39,14 +39,14 @@
 
 @code {
 
-    [Parameter] public string? TagName { get; set; }
+    [Parameter] public string? TagEncodedName { get; set; }
 
     List<Post<BlogFrontMatter>>? posts;
 
     protected override void OnInitialized()
     {
-        if (string.IsNullOrWhiteSpace(TagName)) return;
-        posts = BlazorStaticContentService.Posts.Where(x => x.FrontMatter.Tags.Contains(TagName)).ToList();
+        if (string.IsNullOrWhiteSpace(TagEncodedName)) return;
+        posts = BlazorStaticContentService.Posts.Where(x => x.FrontMatter.Tags.Contains(WebUtility.UrlDecode( TagEncodedName))).ToList();
     }
 
 }

--- a/BlazorStaticWebsite/Components/Pages/Tags.razor
+++ b/BlazorStaticWebsite/Components/Pages/Tags.razor
@@ -18,7 +18,7 @@
 
             foreach(var tag in tagsWithCount)
             {
-                <a class="text-primary-500 hover:text-primary-400 mr-3 text-sm font-medium uppercase" href="@BlazorStaticContentService.Options.TagsPageUrl/@WebUtility.HtmlEncode(tag.Tag)">@tag.Tag (@tag.Count)</a>
+                <a class="text-primary-500 hover:text-primary-400 mr-3 text-sm font-medium uppercase" href="@BlazorStaticContentService.Options.TagsPageUrl/@BlazorStaticContentService.Options.TagEncodeFunc(tag.Tag)"> @tag.Tag (@tag.Count)</a>
             }
         }
     </div>

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
@@ -7,6 +7,9 @@ authors:
   - name: "Jan Tesař"
     gitHubUserName: "tesar-tech"
     xUserName: "tesar_tech"
+  - name: "Patrick T Coakley"
+    gitHubUserName: "patricktcoakley"
+
 ---
 
 ## Breaking Changes

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
@@ -1,0 +1,29 @@
+---
+title: "1.0.0-beta.14 - Tags have encoder, welcome to blazorstatic.net, new BlazorStatic organization, templates are fixed for green button"
+lead: ""
+published: 2024-10-30
+tags: [release, tag encoder, blazorstatic.net , BlazorStatic organization, dotnet new template]
+authors:
+  - name: "Jan Tesař"
+    gitHubUserName: "tesar-tech"
+    xUserName: "tesar_tech"
+---
+
+## Breaking Changes
+
+-
+
+## HotReload
+
+The previous version introduced HotReload, enhancing the development experience when building the site locally. With
+HotReload, every time you update your source code or .md file, BlazorStatic automatically refreshes the post list and
+regenerates all content. Learn more about HotReload [here](docs/hotreload).
+
+## tags have encoders
+
+
+### Feedback
+
+Try out the template and let me know if it meets your expectations or if you need any adjustments.
+Share your feedback [by creating an issue](https://github.com/tesar-tech/BlazorStatic/issues/new) or join the
+conversation in the [Discord server](https://discord.gg/DsAXsMuEbx).

--- a/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
+++ b/BlazorStaticWebsite/Content/Blog/release-1.0.0-beta.14.md
@@ -11,19 +11,10 @@ authors:
 
 ## Breaking Changes
 
--
-
-## HotReload
-
-The previous version introduced HotReload, enhancing the development experience when building the site locally. With
-HotReload, every time you update your source code or .md file, BlazorStatic automatically refreshes the post list and
-regenerates all content. Learn more about HotReload [here](docs/hotreload).
-
 ## tags have encoders
-
 
 ### Feedback
 
 Try out the template and let me know if it meets your expectations or if you need any adjustments.
-Share your feedback [by creating an issue](https://github.com/tesar-tech/BlazorStatic/issues/new) or join the
+Share your feedback [by creating an issue](https://github.com/BlazorStatic/BlazorStatic/issues/new) or join the
 conversation in the [Discord server](https://discord.gg/DsAXsMuEbx).

--- a/BlazorStaticWebsite/Content/Blog/subfolder/post-in-subfolder.md
+++ b/BlazorStaticWebsite/Content/Blog/subfolder/post-in-subfolder.md
@@ -2,7 +2,7 @@
 title: Test post for subfolder
 lead: Just testing if post in subfolder works
 published: 2024-05-29
-tags: [test]
+tags: [test, ci/cd, ci.cd, two words, .net/C#]
 authors:
     - name: "Jan Tesař"
       gitHubUserName: "tesar-tech"

--- a/BlazorStaticWebsite/Program.cs
+++ b/BlazorStaticWebsite/Program.cs
@@ -9,29 +9,30 @@ var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseStaticWebAssets();
 
 builder.Services.AddBlazorStaticService(opt => {
-    opt.IgnoredPathsOnContentCopy.AddRange(["app.css"]);//pre-build version for tailwind
+        opt.IgnoredPathsOnContentCopy.AddRange(["app.css"]);//pre-build version for tailwind
 
-    opt.ContentToCopyToOutput.Add(new ContentToCopy("../.github/media", "media"));
-    opt.ContentToCopyToOutput.Add(new ContentToCopy("Content/Docs/media", "Content/Docs/media"));
+        opt.ContentToCopyToOutput.Add(new ContentToCopy("../.github/media", "media"));
+        opt.ContentToCopyToOutput.Add(new ContentToCopy("Content/Docs/media", "Content/Docs/media"));
 
-    // add docs pages
-    var docsFiles = Directory.GetFiles(Path.Combine("Content", "Docs"), "*.md").Where(x => !x.EndsWith("README.md"));//ignore readme, it is handled in Pages/Docs.razor
+        // add docs pages
+        var docsFiles = Directory.GetFiles(Path.Combine("Content", "Docs"), "*.md").Where(x => !x.EndsWith("README.md"));//ignore readme, it is handled in Pages/Docs.razor
 
-    foreach(var fileName in docsFiles.Select(Path.GetFileNameWithoutExtension))
-    {
-        opt.PagesToGenerate.Add(new PageToGenerate($"/docs/{fileName}", Path.Combine("docs", $"{fileName}.html")));
-    }
+        foreach(var fileName in docsFiles.Select(Path.GetFileNameWithoutExtension))
+        {
+            opt.PagesToGenerate.Add(new PageToGenerate($"/docs/{fileName}", Path.Combine("docs", $"{fileName}.html")));
+        }
 
-    // Must add a site url to generate the Sitemap!
-    opt.ShouldGenerateSitemap = true;
-    opt.SiteUrl = WebsiteKeys.SiteUrl;
-    opt.HotReloadEnabled = true;
-}).AddBlazorStaticContentService<BlogFrontMatter>().AddBlazorStaticContentService<ProjectFrontMatter>(opt => {
-    opt.MediaFolderRelativeToContentPath = null;
-    opt.ContentPath = Path.Combine("Content", "Projects");
-    opt.AddTagPagesFromPosts = false;
-    opt.PageUrl = WebsiteKeys.ProjectsUrl;
-});
+        // Must add a site url to generate the Sitemap!
+        opt.ShouldGenerateSitemap = true;
+        opt.SiteUrl = WebsiteKeys.SiteUrl;
+        opt.HotReloadEnabled = true;
+    }).AddBlazorStaticContentService<BlogFrontMatter>()
+    .AddBlazorStaticContentService<ProjectFrontMatter>(opt => {
+        opt.MediaFolderRelativeToContentPath = null;
+        opt.ContentPath = Path.Combine("Content", "Projects");
+        opt.AddTagPagesFromPosts = false;
+        opt.PageUrl = WebsiteKeys.ProjectsUrl;
+    });
 
 
 // Add services to the container.

--- a/src/BlazorStaticOptions.cs
+++ b/src/BlazorStaticOptions.cs
@@ -4,6 +4,8 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace BlazorStatic;
 
+using System.Net;
+
 /// <summary>
 ///     Options for configuring the BlazorStatic generation process.
 /// </summary>
@@ -185,6 +187,15 @@ public class BlazorStaticContentOptions<TFrontMatter>
     ///     tag pages will be generated from all tags found in blog posts
     /// </summary>
     public bool AddTagPagesFromPosts { get; set; } = true;
+
+    /// <summary>
+    /// Func to convert tag string to file-name/url.
+    /// You might want to change this if you don't like non-alphanumerical chars in your url (like tags/.net%2FC%23)
+    /// The default is WebUtility.UrlEncode, which makes changes, like:
+    /// "nice tag" -> "nice+tag", "ci/cd" -> "ci%2Fcd", ".net/C# " -> ".net%2FC%23".
+    /// Also don't forget to use the same encoder while creating tag links
+    /// </summary>
+    public Func<string,string> TagEncodeFunc { get; set; } = WebUtility.UrlEncode;
 
     /// <summary>
     ///     Should correspond to page that keeps the list of content.

--- a/src/Services/BlazorStaticContentService.cs
+++ b/src/Services/BlazorStaticContentService.cs
@@ -2,6 +2,9 @@ using System.Reflection;
 
 namespace BlazorStatic.Services;
 
+using System.Text.Encodings.Web;
+using System.Web;
+
 /// <summary>
 ///     The BlazorStaticContentService is responsible for parsing and adding blog posts.
 ///     It adds pages with blog posts to the options.PagesToGenerate list,
@@ -88,15 +91,15 @@ public class BlazorStaticContentService<TFrontMatter>(
             var pathWithMedia = Path.Combine(options.ContentPath, options.MediaFolderRelativeToContentPath);
             blazorStaticService.Options.ContentToCopyToOutput.Add(new ContentToCopy(pathWithMedia, pathWithMedia));
         }
-
         //add tags pages
         if(options.AddTagPagesFromPosts)
         {
             // blazorStaticService.Options.PagesToGenerate.Add(new($"{options.TagsPageUrl}", Path.Combine(options.TagsPageUrl, "index.html")));
             foreach(var tag in options.Posts.SelectMany(x => x.FrontMatter.Tags).Distinct())//gather all unique tags from all posts
             {
-                blazorStaticService.Options.PagesToGenerate.Add(new PageToGenerate($"{options.TagsPageUrl}/{tag}",
-                Path.Combine(options.TagsPageUrl, $"{tag}.html")));
+                var encodedTag = options.TagEncodeFunc(tag);
+                blazorStaticService.Options.PagesToGenerate.Add(new PageToGenerate($"{options.TagsPageUrl}/{encodedTag}",
+                Path.Combine(options.TagsPageUrl, $"{encodedTag}.html")));
             }
         }
 


### PR DESCRIPTION
closes #46 

- now the tags with non-url characters are converted by WebUtility.UrlEncode.. 
- The encoder can be changed, since it's just a Func<string, string> that can be set by `opt.TagEncodeFunc` in program.cs. 


to discussion:
- shouldn't we also provide a class for tag itself? Currently `Tags` are defined as List of strings, but maybe it would be more convenient to keep them as ` List<Tag> Tags ` where:
 
```
public class Tag
{
prop Name;
prop EncodedName;
}
```


This would force users to use correct version when working with tag..

That would be quite a breaking change since the Tags are defined in `IFrontMatter`.


