### PR TITLE
Add support for multiple routes in a single page

### DIFF
--- a/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
+++ b/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
@@ -1,6 +1,6 @@
 @page "/MultiRoute"
 @page "/MultiPathDemo"
-@page "/RouteRoulette"
+@attribute [Route("/RouteRoulette")]
 
 <PageTitle>Multiple Routes Showcase</PageTitle>
 

--- a/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
+++ b/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
@@ -4,18 +4,31 @@
 
 <PageTitle>Multiple Routes Showcase</PageTitle>
 
-<h1>Multiple Routes Showcase</h1>
+<div class="prose prose-lg max-w-3xl mx-auto mt-10 font-tomorrow">
+    <h1>Multiple Routes Showcase</h1>
 
-<p>
-    BlazorStatic supports having multiple routes in a single page, and this page is an example of that.
-</p>
+    <p>
+        BlazorStatic supports having multiple routes in a single page, and this page is an example of that.
+    </p>
 
-<a href="MultiRoute">first route</a> <br />
-<a href="MultiPathDemo">second route</a> <br />
-<a href="RouteRoulette">third route</a> <br />
+    <div class="space-y-2">
+        <a href="MultiRoute"
+           class="inline-block px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition">
+            First route
+        </a><br />
+        <a href="MultiPathDemo"
+           class="inline-block px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition">
+            Second route
+        </a><br />
+        <a href="RouteRoulette"
+           class="inline-block px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition">
+            Third route
+        </a>
+    </div>
 
-<h1>Where can this be useful?</h1>
+    <h1>Where can this be useful?</h1>
 
-<p>
-    It can be used for route based localization, for example <code>/en/blogs</code>
-</p>
+    <p>
+        It can be used for route-based localization, for example <code>/en/blogs</code>
+    </p>
+</div>

--- a/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
+++ b/BlazorStaticWebsite/Components/Pages/MultiRoutes.razor
@@ -1,0 +1,21 @@
+@page "/MultiRoute"
+@page "/MultiPathDemo"
+@page "/RouteRoulette"
+
+<PageTitle>Multiple Routes Showcase</PageTitle>
+
+<h1>Multiple Routes Showcase</h1>
+
+<p>
+    BlazorStatic supports having multiple routes in a single page, and this page is an example of that.
+</p>
+
+<a href="MultiRoute">first route</a> <br />
+<a href="MultiPathDemo">second route</a> <br />
+<a href="RouteRoulette">third route</a> <br />
+
+<h1>Where can this be useful?</h1>
+
+<p>
+    It can be used for route based localization, for example <code>/en/blogs</code>
+</p>

--- a/BlazorStaticWebsite/Content/Docs/README.md
+++ b/BlazorStaticWebsite/Content/Docs/README.md
@@ -12,5 +12,7 @@
 
 - Read about [HotReload](docs/hotreload).
 
+- Read about [Multiple Routes support](MultiRoute).
+
 - How to produce BlazorStatic app from scratch is described [here](docs/new-start).
 - How to use BlazorStatic with FluentUI or any other component library is described [here](docs/componentlibs).

--- a/src/BlazorStatic.csproj
+++ b/src/BlazorStatic.csproj
@@ -17,8 +17,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="../README.md" Pack="true" PackagePath="/"/> <!--    readme from the repository root--> 
-    <None Include="../BlazorStaticWebsite/wwwroot/imgs/logo.png" Pack="true" PackagePath="/BlazorStaticWebsite/wwwroot/imgs/"/><!--    logo to match what is inside the readme.md--> 
+    <None Include="../README.md" Pack="true" PackagePath="/"/> <!--    readme from the repository root-->
+    <None Include="../BlazorStaticWebsite/wwwroot/imgs/logo.png" Pack="true" PackagePath="/BlazorStaticWebsite/wwwroot/imgs/"/><!--    logo to match what is inside the readme.md-->
   </ItemGroup>
 
   <PropertyGroup>
@@ -26,7 +26,7 @@
     <Product>BlazorStatic</Product>
     <Description>Static site generator for Blazor</Description>
     <PackageId>BlazorStatic</PackageId>
-    <Version Condition="'$(EnvironmentName)' != 'Development'">1.0.0-beta.14</Version>
+    <Version Condition="'$(EnvironmentName)' != 'Development'">1.0.0-beta.15</Version>
     <!--Set EnvironmentName using dotnet build -c Release -p:EnvironmentName=Development for local package build-->
     <Version Condition="'$(EnvironmentName)' == 'Development'">1.0.0-dev.$([System.DateTime]::Now.ToString("yyMMddHHmmss"))</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/Services/RoutesHelper.cs
+++ b/src/Services/RoutesHelper.cs
@@ -3,36 +3,44 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorStatic.Services;
 
-// borrowed code with minor changes
-// https://andrewlock.net/finding-all-routable-components-in-a-webassembly-app/
+/// <summary>
+/// RoutesHelper is responsible for extracting static, non-parameterized routes from Blazor components within a given assembly. <br />
+/// code is borrowed with some changes from:
+/// https://andrewlock.net/finding-all-routable-components-in-a-webassembly-app/
+/// </summary>
 internal static class RoutesHelper
 {
     /// <summary>
     ///     Gets the static routes of a blazor app
     /// </summary>
     /// <param name="assembly">assembly of the blazor app</param>
-    /// <returns>a list of static routes</returns>
+    /// <returns>An array of static routes</returns>
     public static string[] GetRoutesToRender(Assembly assembly)
     {
         return assembly.ExportedTypes
             .Where(t => t.IsSubclassOf(typeof(ComponentBase)))
-            .SelectMany(GetRouteFromComponent)
+            .SelectMany(GetRoutesFromComponent)
             .OfType<string>()
             .ToArray();
     }
 
     /// <summary>
-    ///     Gets the routes from a blazor component
+    ///     Gets the static routes of a blazor component
     /// </summary>
     /// <param name="component"></param>
-    /// <returns>The routes of the component.</returns>
-    private static string[] GetRouteFromComponent(Type component)
+    /// <returns>
+    ///     An array of static routes. <br />
+    ///     Array values can contain null. <br />
+    ///     Returns an empty array if the component doesn't have `@page` directive.
+    /// </returns>
+    private static string[] GetRoutesFromComponent(Type component)
     {
         var attributes = component.GetCustomAttributes(typeof(RouteAttribute), inherit: false);
         var routes = new string[attributes.Length];
         for(int i = 0; i < attributes.Length; i++)
         {
             var attr = (RouteAttribute)attributes[i];
+            // Ignore parameterized routes (e.g /{Id}) because we can't generate them.
             if(!attr.Template.Contains('{'))
             {
                 routes[i] = attr.Template;

--- a/src/Services/RoutesHelper.cs
+++ b/src/Services/RoutesHelper.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Components;
 using System.Reflection;
+using Microsoft.AspNetCore.Components;
 
 namespace BlazorStatic.Services;
 
@@ -12,36 +12,32 @@ internal static class RoutesHelper
     /// </summary>
     /// <param name="assembly">assembly of the blazor app</param>
     /// <returns>a list of static routes</returns>
-    public static List<string> GetRoutesToRender(Assembly assembly)
+    public static string[] GetRoutesToRender(Assembly assembly)
     {
-        // Get all the components whose base class is ComponentBase
-        var components = assembly
-            .ExportedTypes
-            .Where(t => t.IsSubclassOf(typeof(ComponentBase)));
-
-        // get all the routes that don't contain parameters
-        List<string> routes = components
-            .Select(GetRouteFromComponent)
-            .Where(route => route is not null)
-            .ToList()!;//previous null check guarantee not nulls 
-
-        return routes;
+        return assembly.ExportedTypes
+            .Where(t => t.IsSubclassOf(typeof(ComponentBase)))
+            .SelectMany(GetRouteFromComponent)
+            .OfType<string>()
+            .ToArray();
     }
 
     /// <summary>
-    ///     Gets the route from a blazor component
+    ///     Gets the routes from a blazor component
     /// </summary>
     /// <param name="component"></param>
-    /// <returns>
-    ///     The route of the component.
-    ///     Returns null if the component is not a page (doesn't have RouteAttr) or the route has parameters.
-    /// </returns>
-    private static string? GetRouteFromComponent(Type component)
+    /// <returns>The routes of the component.</returns>
+    private static string[] GetRouteFromComponent(Type component)
     {
-        var attributes = component.GetCustomAttributes(true);
-
-        // can't work with parameterized pages (such pages has params defined with {paramName})
-        return attributes.OfType<RouteAttribute>()
-            .FirstOrDefault(x => !x.Template.Contains('{'))?.Template;
+        var attributes = component.GetCustomAttributes(typeof(RouteAttribute), inherit: false);
+        var routes = new string[attributes.Length];
+        for(int i = 0; i < attributes.Length; i++)
+        {
+            var attr = (RouteAttribute)attributes[i];
+            if(!attr.Template.Contains('{'))
+            {
+                routes[i] = attr.Template;
+            }
+        }
+        return routes;
     }
 }


### PR DESCRIPTION
Add support for pages that have multiple routes, and some performance improvements.

example:

```razor
@page "/blogs"
@page "/ar/blogs"
```

Previously only the first route (`/blogs` in this example) will be generated.

This is can be useful for adding translations to a site (i'm working on an example)